### PR TITLE
Fix file backend object rule path

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ all: auth-plugin.so
 backends/backend.o: backends/backend.cpp
 backends/http/be_http.o: backends/http/be_http.cpp
 backends/mysql/be_mysql.o: backends/mysql/be_mysql.cpp
-backends/sqlite/be_file.o: backends/sqlite/be_file.cpp
+backends/file/be_file.o: backends/file/be_file.cpp
 backends/sqlite/be_sqlite.o: backends/sqlite/be_sqlite.cpp
 mosquitto-plugin-main.o: mosquitto-plugin-main.cpp
 plugin.o: plugin.cpp


### PR DESCRIPTION
## Summary
- fix `src/Makefile` rule for file backend object to point to `backends/file`

## Testing
- `make clean && make` *(fails: `/usr/bin/clang++` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acdcd8984832a933b22c9a4d089f1