### PR TITLE
Fix HTTP headers cleanup

### DIFF
--- a/src/backends/http/be_http.cpp
+++ b/src/backends/http/be_http.cpp
@@ -104,6 +104,8 @@ bool BE_Http::authenticate(const std::string& username, const std::string& passw
         curl_easy_cleanup(curl);
     }
 
+    curl_slist_free_all(headers);
+
     curl_global_cleanup();
 
     if(res == CURLE_OK)


### PR DESCRIPTION
## Summary
- ensure HTTP backend frees libcurl headers list

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686acd637770832aa3d7080132d80742