### PR TITLE
Add auth debug option to file backend

### DIFF
--- a/src/backends/file/be_file.cpp
+++ b/src/backends/file/be_file.cpp
@@ -26,7 +26,8 @@ bool BE_File::initialize(const std::map<std::string, std::string>& options)
         return false;
     }
 
-    m_debug_auth = (options.count(c_debug_auth_key) != 0 && options.at(c_debug_auth_key) == "true");
+    auto it = options.find(c_debug_auth_key);
+    m_debug_auth = (it != options.end() && it->second == "true");
 
     const std::string& credentialsFilePath = options.at(c_file_opt_key);
     auto credentials = loadFile(credentialsFilePath);

--- a/src/backends/file/be_file.h
+++ b/src/backends/file/be_file.h
@@ -65,4 +65,6 @@ private:
 
     using Credentials = std::pair<std::string, std::string>;
     std::vector<Credentials> m_credentials;
+
+    bool m_debug_auth {false};
 };


### PR DESCRIPTION
## Summary
- remove global auth debug support from `Plugin`
- store a `debug_auth` option in the file backend
- log the username and hashed password when authentication occurs if `debug_auth` is enabled
- address PR feedback to keep plugin.cpp untouched and adjust verbose logging message

## Testing
- `make -C src auth-plugin.so`
- `make -C src clean`


------
https://chatgpt.com/codex/tasks/task_e_686accb99200832aa23adbf3e477df55