### PR TITLE
Add debugging toggle and outcome logs

### DIFF
--- a/src/backends/file/be_file.cpp
+++ b/src/backends/file/be_file.cpp
@@ -54,14 +54,14 @@ std::optional<std::vector<std::pair<std::string, std::string>>> BE_File::loadFil
 
     auto file = std::ifstream(filePath);
     std::string line;
-    int lineNb = 1;
+    size_t lineNb = 1;
     while (getline(file, line))
     {
         int iSep = line.find_last_of("::");
         if (iSep == std::string::npos)
         {
             mosquitto_log_printf(MOSQ_LOG_WARNING,
-                                 "*** auth-plugin: line %i is malformed, skipping it",
+                                 "*** auth-plugin: line %zu is malformed, skipping it",
                                  lineNb);
             ++lineNb;
             continue;
@@ -74,7 +74,7 @@ std::optional<std::vector<std::pair<std::string, std::string>>> BE_File::loadFil
         if (m_debug_auth)
         {
             mosquitto_log_printf(MOSQ_LOG_DEBUG,
-                                 "*** auth-plugin: credential[%i] username=%s password=%s",
+                                 "*** auth-plugin: credential[%zu] username=%s password=%s",
                                  lineNb,
                                  username.c_str(),
                                  password.c_str());
@@ -85,7 +85,7 @@ std::optional<std::vector<std::pair<std::string, std::string>>> BE_File::loadFil
         ++lineNb;
     }
 
-    mosquitto_log_printf(MOSQ_LOG_INFO, "*** auth-plugin: loaded %i credentials from `%s`", credentials.size(), filePath.c_str());
+    mosquitto_log_printf(MOSQ_LOG_INFO, "*** auth-plugin: loaded %zu credentials from `%s`", credentials.size(), filePath.c_str());
 
     return credentials;
 }

--- a/src/backends/file/be_file.cpp
+++ b/src/backends/file/be_file.cpp
@@ -106,16 +106,22 @@ bool BE_File::authenticate(const std::string& username, const std::string& passw
     {
         if (item.first == username && item.second == input_hash)
         {
-            mosquitto_log_printf(MOSQ_LOG_DEBUG,
-                                 "*** auth-plugin: authentication succeeded for '%s'",
-                                 username.c_str());
+            if (m_debug_auth)
+            {
+                mosquitto_log_printf(MOSQ_LOG_DEBUG,
+                                     "*** auth-plugin: authentication succeeded for '%s'",
+                                     username.c_str());
+            }
             return true;
         }
     }
 
-    mosquitto_log_printf(MOSQ_LOG_DEBUG,
-                         "*** auth-plugin: authentication failed for '%s'",
-                         username.c_str());
+    if (m_debug_auth)
+    {
+        mosquitto_log_printf(MOSQ_LOG_DEBUG,
+                             "*** auth-plugin: authentication failed for '%s'",
+                             username.c_str());
+    }
     return false;
 }
 

--- a/src/backends/file/be_file.cpp
+++ b/src/backends/file/be_file.cpp
@@ -71,11 +71,14 @@ std::optional<std::vector<std::pair<std::string, std::string>>> BE_File::loadFil
         size_t remaining = line.size() - username.size() - 3U; // 2 chars for the separator and 1 for end of line
         std::string password = line.substr(iSep + 1, remaining);
 
-        mosquitto_log_printf(MOSQ_LOG_DEBUG,
-                             "*** auth-plugin: credential[%i] username=%s password=%s",
-                             lineNb,
-                             username.c_str(),
-                             password.c_str());
+        if (m_debug_auth)
+        {
+            mosquitto_log_printf(MOSQ_LOG_DEBUG,
+                                 "*** auth-plugin: credential[%i] username=%s password=%s",
+                                 lineNb,
+                                 username.c_str(),
+                                 password.c_str());
+        }
 
         credentials.emplace_back(make_pair(std::move(username), std::move(password)));
 
@@ -103,10 +106,16 @@ bool BE_File::authenticate(const std::string& username, const std::string& passw
     {
         if (item.first == username && item.second == input_hash)
         {
+            mosquitto_log_printf(MOSQ_LOG_DEBUG,
+                                 "*** auth-plugin: authentication succeeded for '%s'",
+                                 username.c_str());
             return true;
         }
     }
 
+    mosquitto_log_printf(MOSQ_LOG_DEBUG,
+                         "*** auth-plugin: authentication failed for '%s'",
+                         username.c_str());
     return false;
 }
 


### PR DESCRIPTION
## Summary
- respect `debug_auth` when printing credentials in the file backend
- log authentication success or failure in the file backend

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_686b12421268832ab1a47c331b7a65e3