### PR TITLE
Fix newline handling in file backend

### DIFF
--- a/src/backends/file/be_file.cpp
+++ b/src/backends/file/be_file.cpp
@@ -68,7 +68,7 @@ std::optional<std::vector<std::pair<std::string, std::string>>> BE_File::loadFil
         }
 
         std::string username = line.substr(0, iSep - 1); // -1 brings us back to the beginning of the separator
-        size_t remaining = line.size() - username.size() - 3U; // 2 chars for the separator and 1 for end of line
+        size_t remaining = line.size() - username.size() - 2U; // 2 chars for the separator
         std::string password = line.substr(iSep + 1, remaining);
 
         if (m_debug_auth)


### PR DESCRIPTION
## Summary
- ensure `BE_File::loadFile` does not subtract a non-existent newline when parsing passwords

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_686b179055ac832a9537194ccbf2ed9c