### PR TITLE
Initialize curl in HTTP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ plugin_opt_http_acl_path /acl
 
 The credentials file used by the file backend must contain entries of the form `username::sha256(password)` on separate lines. The HTTP backend sends JSON requests to the configured endpoints.
 
+The HTTP backend initializes libcurl when it is loaded and cleans up the
+library on shutdown, so HTTP requests incur no extra initialization overhead.
+
 ## 💻 Devcontainer & Codespaces
 
 The repository includes a `.devcontainer` folder so you can open it in Visual Studio Code or GitHub Codespaces and get a fully configured environment automatically.

--- a/src/backends/http/be_http.cpp
+++ b/src/backends/http/be_http.cpp
@@ -13,8 +13,15 @@ BE_Http::BE_Http(const std::map<std::string, std::string>& options)
 {
     mosquitto_log_printf(MOSQ_LOG_DEBUG, "*** auth-plugin: backend %s initializing", BE_Http::kind);
 
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+
     setupBaseUri(options);
     setupSubpaths(options);
+}
+
+BE_Http::~BE_Http()
+{
+    curl_global_cleanup();
 }
 
 void BE_Http::setupBaseUri(const std::map<std::string, std::string>& options) noexcept
@@ -76,7 +83,6 @@ bool BE_Http::authenticate(const std::string& username, const std::string& passw
         return false;
     }
 
-    curl_global_init(CURL_GLOBAL_ALL);
 
     std::ostringstream url;
     url << m_base_uri << m_auth_path;
@@ -106,7 +112,6 @@ bool BE_Http::authenticate(const std::string& username, const std::string& passw
 
     curl_slist_free_all(headers);
 
-    curl_global_cleanup();
 
     if(res == CURLE_OK)
     {

--- a/src/backends/http/be_http.cpp
+++ b/src/backends/http/be_http.cpp
@@ -13,15 +13,28 @@ BE_Http::BE_Http(const std::map<std::string, std::string>& options)
 {
     mosquitto_log_printf(MOSQ_LOG_DEBUG, "*** auth-plugin: backend %s initializing", BE_Http::kind);
 
-    curl_global_init(CURL_GLOBAL_DEFAULT);
+    CURLcode init_code = curl_global_init(CURL_GLOBAL_DEFAULT);
+    if (init_code != CURLE_OK)
+    {
+        mosquitto_log_printf(MOSQ_LOG_ERR,
+                             "*** auth-plugin: curl_global_init failed: %s",
+                             curl_easy_strerror(init_code));
+    }
+    else
+    {
+        m_curl_initialized = true;
+    }
 
     setupBaseUri(options);
     setupSubpaths(options);
 }
 
-BE_Http::~BE_Http()
+BE_Http::~BE_Http() noexcept
 {
-    curl_global_cleanup();
+    if (m_curl_initialized)
+    {
+        curl_global_cleanup();
+    }
 }
 
 void BE_Http::setupBaseUri(const std::map<std::string, std::string>& options) noexcept

--- a/src/backends/http/be_http.h
+++ b/src/backends/http/be_http.h
@@ -17,6 +17,7 @@ public:
      * @param options The relevant `mosquitto_opt` from the broker's config file
      */
     BE_Http(const std::map<std::string, std::string>& options);
+    ~BE_Http();
 
     /**
      * Verifies a client credentials against the Http store

--- a/src/backends/http/be_http.h
+++ b/src/backends/http/be_http.h
@@ -17,7 +17,7 @@ public:
      * @param options The relevant `mosquitto_opt` from the broker's config file
      */
     BE_Http(const std::map<std::string, std::string>& options);
-    ~BE_Http();
+    ~BE_Http() noexcept;
 
     /**
      * Verifies a client credentials against the Http store
@@ -53,6 +53,7 @@ private:
     void setupBaseUri(const std::map<std::string, std::string>& options) noexcept;
     void setupSubpaths(const std::map<std::string, std::string>& options) noexcept;
 
+    bool m_curl_initialized = false;
     std::string m_base_uri;
     std::string m_auth_path = "/auth";
     std::string m_acl_path = "/acl";


### PR DESCRIPTION
## Summary
- move libcurl initialization to BE_Http constructor/destructor
- drop libcurl setup from Plugin
- document HTTP backend's responsibility for curl setup

## Testing
- `make` *(fails: `mosquitto_plugin.h` missing)*
- `make clean`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6871d8a9d6f0832aace9003d10684687