### PR TITLE
Switch file backend to argon2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently a file based backend and an HTTP backend are implemented. MySQL and SQ
 The project uses `clang` and requires Mosquitto development headers. On Alpine based systems the following packages are needed:
 
 ```
-apk add clang clang-extra-tools mosquitto-dev mariadb-dev sqlite-dev curl
+apk add clang clang-extra-tools mosquitto-dev mariadb-dev sqlite-dev curl argon2-dev
 ```
 
 To compile the plugin run:
@@ -53,7 +53,19 @@ plugin_opt_http_auth_path /auth
 plugin_opt_http_acl_path /acl
 ```
 
-The credentials file used by the file backend must contain entries of the form `username::sha256(password)` on separate lines. The HTTP backend sends JSON requests to the configured endpoints.
+The credentials file used by the file backend must contain entries of the form `username::<argon2id-hash>` on separate lines. You can generate a hash using the `argon2` utility, e.g.:
+
+```sh
+echo -n 'password' | argon2 somesalt -id -t 2 -m 16 -p 1 -e
+```
+
+The HTTP backend sends JSON requests to the configured endpoints.
+
+### Migrating existing credentials
+
+Older versions of the plugin used plain SHA-256 hashes. Regenerate each password
+with the `argon2` utility and replace the stored value in `creds.txt` with the
+new Argon2id hash.
 
 ## 💻 Devcontainer & Codespaces
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ CC = /usr/bin/clang
 CXX = /usr/bin/clang++
 
 CXXFLAGS = -fPIC --std=c++23
-LDFLAGS = -static-libstdc++ -static-libgcc -lcurl
+LDFLAGS = -static-libstdc++ -static-libgcc -lcurl -largon2
 
 OBJS = \
 	./backends/backend.o \
@@ -11,8 +11,7 @@ OBJS = \
 	./backends/mysql/be_mysql.o \
 	./backends/sqlite/be_sqlite.o \
 	./mosquitto-plugin-main.o \
-	./plugin.o \
-	./utils/sha256.o \
+        ./plugin.o \
 
 all: auth-plugin.so
 
@@ -23,7 +22,6 @@ backends/file/be_file.o: backends/file/be_file.cpp
 backends/sqlite/be_sqlite.o: backends/sqlite/be_sqlite.cpp
 mosquitto-plugin-main.o: mosquitto-plugin-main.cpp
 plugin.o: plugin.cpp
-utils/sha256.o: utils/sha256.cpp
 
 auth-plugin.so: $(OBJS)
 	$(CXX) $(CXXFLAGS) -shared -o $@ $(OBJS) $(LDFLAGS)

--- a/src/backends/file/be_file.h
+++ b/src/backends/file/be_file.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "../backend.h"
-#include "../../utils/sha256.h"
+#include <argon2.h>
+#include <string>
 
 #include <optional>
 #include <vector>


### PR DESCRIPTION
## Summary
- use argon2id instead of SHA-256 for file backend credentials
- link against argon2 and update build dependencies
- document new credential file format and migration steps

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6871d8baf4cc832a81ed85ccd5281e44